### PR TITLE
fix(release): Manually release a major version

### DIFF
--- a/other/manual-releases.md
+++ b/other/manual-releases.md
@@ -1,0 +1,50 @@
+# manual-releases
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+This project has an automated release set up. So things are only released when
+there are useful changes in the code that justify a release. But sometimes
+things get messed up one way or another and we need to trigger the release
+ourselves. When this happens, simply bump the number below and commit that with
+the following commit message based on your needs:
+
+**Major**
+
+```
+fix(release): Manually release a major version
+
+There was an issue with a major release, so this manual-releases.md
+change is to release a new major version.
+
+Reference: #<the number of a relevant pull request, issue, or commit>
+
+BREAKING CHANGE: <mention any relevant breaking changes (this is what triggers the major version change so don't skip this!)>
+```
+
+**Minor**
+
+```
+feat(release): Manually release a minor version
+
+There was an issue with a minor release, so this manual-releases.md
+change is to release a new minor version.
+
+Reference: #<the number of a relevant pull request, issue, or commit>
+```
+
+**Patch**
+
+```
+fix(release): Manually release a patch version
+
+There was an issue with a patch release, so this manual-releases.md
+change is to release a new patch version.
+
+Reference: #<the number of a relevant pull request, issue, or commit>
+```
+
+The number of times we've had to do a manual release is: 1


### PR DESCRIPTION
There was an issue with a major release, so this manual-releases.md change is to release a new major
version.

BREAKING CHANGE: I fucked up the history of this repo. Therefore I'm triggering a major release and
hoping to do better in the future.